### PR TITLE
Add QC inputs for radiopharmaceuticals

### DIFF
--- a/app/radiopharmaceutical/radiopharmaceutical.py
+++ b/app/radiopharmaceutical/radiopharmaceutical.py
@@ -75,7 +75,10 @@ def _ensure_at_least_one_set(table_mgr, username):
                 'type': pharm_type,
                 'half_life': half_life,
                 'price': "",
-                'time_slots': ["anytime"]
+                'time_slots': ["anytime"],
+                'qc_amount': "",
+                'qc_unit': "percent",
+                'qc_time': ""
             }
             for pharm_type, half_life in sorted(DEFAULT_TYPES)
         ]
@@ -158,13 +161,16 @@ def manage():
     except Exception:
         pharm_list = []
 
-    # Ensure each 'time_slots' is a list
+    # Ensure 'time_slots' is a list and QC fields exist
     for item in pharm_list:
         if 'time_slots' in item and not isinstance(item['time_slots'], list):
             try:
                 item['time_slots'] = json.loads(item['time_slots'])
             except Exception:
                 item['time_slots'] = []
+        item.setdefault('qc_amount', "")
+        item.setdefault('qc_unit', "percent")
+        item.setdefault('qc_time', "")
 
     return render_template(
         'radiopharmaceutical.html',
@@ -328,6 +334,9 @@ def add_radiopharm():
         half_life = request.form.get('half_life', "")
         price = request.form.get('price', "")
         time_slots = request.form.getlist('time_slots')
+        qc_amount = request.form.get('qc_amount', "")
+        qc_unit = request.form.get('qc_unit', "percent")
+        qc_time = request.form.get('qc_time', "")
 
         try:
             ent = table_mgr.get_entity(PHARM_TABLE, username, current_set)
@@ -339,7 +348,10 @@ def add_radiopharm():
             'type': name,
             'half_life': half_life,
             'price': price,
-            'time_slots': time_slots
+            'time_slots': time_slots,
+            'qc_amount': qc_amount,
+            'qc_unit': qc_unit,
+            'qc_time': qc_time
         })
 
         updated_ent = {
@@ -382,12 +394,18 @@ def edit_radiopharm(index):
         half_life = request.form.get('half_life', "")
         price = request.form.get('price', "")
         time_slots = request.form.getlist('time_slots')
+        qc_amount = request.form.get('qc_amount', "")
+        qc_unit = request.form.get('qc_unit', "percent")
+        qc_time = request.form.get('qc_time', "")
 
         pharm_list[index] = {
             'type': name,
             'half_life': half_life,
             'price': price,
-            'time_slots': time_slots
+            'time_slots': time_slots,
+            'qc_amount': qc_amount,
+            'qc_unit': qc_unit,
+            'qc_time': qc_time
         }
 
         updated_ent = {
@@ -405,6 +423,9 @@ def edit_radiopharm(index):
         return redirect(url_for('radiopharm.manage'))
 
     record = pharm_list[index]
+    record.setdefault('qc_amount', "")
+    record.setdefault('qc_unit', "percent")
+    record.setdefault('qc_time', "")
     return render_template('edit_radiopharm.html', record=record, index=index)
 
 

--- a/app/radiopharmaceutical/templates/add_radiopharm.html
+++ b/app/radiopharmaceutical/templates/add_radiopharm.html
@@ -38,8 +38,20 @@
         <option value="{{ h00 }}">{{ h00 }}</option>
         <option value="{{ h30 }}">{{ h30 }}</option>
       {% endfor %}
-      <option value="17:00">17:00</option>
+    <option value="17:00">17:00</option>
+  </select>
+  </div>
+  <div>
+    <label for="qc_amount">QC Amount:</label>
+    <input type="number" step="any" name="qc_amount" id="qc_amount" required style="width:80px;">
+    <select name="qc_unit" id="qc_unit">
+      <option value="percent">%</option>
+      <option value="MBq">MBq</option>
     </select>
+  </div>
+  <div>
+    <label for="qc_time">QC Time (min):</label>
+    <input type="number" step="any" name="qc_time" id="qc_time" required>
   </div>
   <button type="submit">Add Radiopharmaceutical</button>
 </form>

--- a/app/radiopharmaceutical/templates/edit_radiopharm.html
+++ b/app/radiopharmaceutical/templates/edit_radiopharm.html
@@ -38,8 +38,20 @@
         <option value="{{ h00 }}" {% if h00 in record.time_slots %}selected{% endif %}>{{ h00 }}</option>
         <option value="{{ h30 }}" {% if h30 in record.time_slots %}selected{% endif %}>{{ h30 }}</option>
       {% endfor %}
-      <option value="17:00" {% if '17:00' in record.time_slots %}selected{% endif %}>17:00</option>
+    <option value="17:00" {% if '17:00' in record.time_slots %}selected{% endif %}>17:00</option>
+  </select>
+  </div>
+  <div>
+    <label for="qc_amount">QC Amount:</label>
+    <input type="number" step="any" name="qc_amount" id="qc_amount" value="{{ record.qc_amount }}" required style="width:80px;">
+    <select name="qc_unit" id="qc_unit">
+      <option value="percent" {% if record.qc_unit == 'percent' %}selected{% endif %}>%</option>
+      <option value="MBq" {% if record.qc_unit == 'MBq' %}selected{% endif %}>MBq</option>
     </select>
+  </div>
+  <div>
+    <label for="qc_time">QC Time (min):</label>
+    <input type="number" step="any" name="qc_time" id="qc_time" value="{{ record.qc_time }}" required>
   </div>
   <button type="submit">Save Changes</button>
 </form>

--- a/app/radiopharmaceutical/templates/radiopharmaceutical.html
+++ b/app/radiopharmaceutical/templates/radiopharmaceutical.html
@@ -90,7 +90,11 @@
           <td>{{ record.half_life }}</td>
           <td>{{ record.price }}</td>
           <td>{{ record.time_slots | join(', ') }}</td>
-          <td>mins + % / abs (act)</td>
+          <td>
+            {% if record.qc_amount %}
+              {{ record.qc_amount }}{% if record.qc_unit == 'percent' %}%{% else %} MBq{% endif %} / {{ record.qc_time }} min
+            {% endif %}
+          </td>
           <td>
             <div class="action-buttons" style="display: flex; gap: 0.5em;">
               <a href="{{ url_for('radiopharm.edit_radiopharm', index=loop.index0) }}">


### PR DESCRIPTION
## Summary
- support QC amount and duration when adding/editing radiopharmaceuticals
- show QC info in the radiopharmaceutical list

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ec64c63748327af78ac920c4354b7