### PR TITLE
Add radionuclide blueprint and update radiopharmaceuticals

### DIFF
--- a/app/app_init.py
+++ b/app/app_init.py
@@ -6,6 +6,7 @@ from app.dosing_schemes.dosing_schemes import dosing_bp
 from app.optim.optim import optim_bp
 from app.patients.patients import patients_bp
 from app.radiopharmaceutical.radiopharmaceutical import radiopharm_bp
+from app.radionuclide.radionuclide import radionuclide_bp
 from app.table_manager import get_table_manager
 from app.tests.tests import tests_bp
 
@@ -26,6 +27,7 @@ def init_app(app):
     login_manager.init_app(app)
 
     app.register_blueprint(user_bp)
+    app.register_blueprint(radionuclide_bp, url_prefix="/radionuclides")
     app.register_blueprint(radiopharm_bp, url_prefix="/radiopharm")
     app.register_blueprint(dosing_bp, url_prefix="/dosing")
     app.register_blueprint(daysetup_bp, url_prefix="/daysetup")
@@ -44,6 +46,11 @@ def init_app(app):
         app.logger.info("Azure table 'pharmaceutical' created or already exists.")
     except Exception as e:
         app.logger.error("Failed to create azure table 'pharmaceutical': %s", e)
+    try:
+        table_manager.create_table(RADIONUCLIDE_TABLE)
+        app.logger.info("Azure table 'radionuclides' created or already exists.")
+    except Exception as e:
+        app.logger.error("Failed to create azure table 'radionuclides': %s", e)
     try:
         table_manager.create_table(DOSING_SCHEMES_TABLE)
         app.logger.info("Azure table 'dosing_schemes' created or already exists.")

--- a/app/constants.py
+++ b/app/constants.py
@@ -5,3 +5,5 @@ DOSING_SCHEMES_TABLE = "dosingschemes"  # Use the same name as the Azure table
 PATIENTS_TABLE = "patients"
 TESTS_TABLE = 'Tests'
 TEST_PATIENTS_TABLE = 'TestPatients'
+
+RADIONUCLIDE_TABLE = "radionuclides"

--- a/app/radionuclide/radionuclide.py
+++ b/app/radionuclide/radionuclide.py
@@ -1,0 +1,104 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask_login import login_required, current_user
+
+from app.constants import RADIONUCLIDE_TABLE
+from app.table_manager import get_table_manager
+
+radionuclide_bp = Blueprint('radionuclides', __name__, template_folder='templates')
+
+DEFAULT_NUCLIDES = [
+    ('18F', 109.8),
+    ('68Ga', 67.7),
+    ('11C', 20.4),
+    ('15O', 2.03),
+    ('13N', 9.96),
+]
+
+
+@login_required
+@radionuclide_bp.route('/radionuclides', methods=['GET'])
+def manage_radionuclides():
+    table_mgr = get_table_manager()
+    username = current_user.username
+
+    radionuclides = list(table_mgr.query_entities(RADIONUCLIDE_TABLE, f"PartitionKey eq '{username}'"))
+    if not radionuclides:
+        batch = [
+            {
+                'PartitionKey': username,
+                'RowKey': name,
+                'half_life': half_life,
+            }
+            for name, half_life in DEFAULT_NUCLIDES
+        ]
+        table_mgr.upload_batch_to_table(RADIONUCLIDE_TABLE, batch)
+        radionuclides = batch
+
+    radionuclides = sorted(radionuclides, key=lambda r: r['RowKey'])
+    return render_template('radionuclide.html', radionuclides=radionuclides)
+
+
+@login_required
+@radionuclide_bp.route('/radionuclides/add', methods=['GET', 'POST'])
+def add_radionuclide():
+    if request.method == 'POST':
+        name = request.form.get('name', '').strip()
+        try:
+            half_life = float(request.form.get('half_life'))
+        except (ValueError, TypeError):
+            flash('Half life must be a number.', 'error')
+            return redirect(url_for('radionuclides.add_radionuclide'))
+
+        if not name:
+            flash('Name is required.', 'error')
+            return redirect(url_for('radionuclides.add_radionuclide'))
+
+        table_mgr = get_table_manager()
+        username = current_user.username
+        entity = {
+            'PartitionKey': username,
+            'RowKey': name,
+            'half_life': half_life,
+        }
+        table_mgr.upload_batch_to_table(RADIONUCLIDE_TABLE, [entity])
+        flash('Radionuclide added.', 'success')
+        return redirect(url_for('radionuclides.manage_radionuclides'))
+
+    return render_template('add_radionuclide.html')
+
+
+@login_required
+@radionuclide_bp.route('/radionuclides/edit/<row_key>', methods=['GET', 'POST'])
+def edit_radionuclide(row_key):
+    table_mgr = get_table_manager()
+    username = current_user.username
+    entity = table_mgr.get_entity(RADIONUCLIDE_TABLE, username, row_key)
+    if not entity:
+        flash('Radionuclide not found.', 'error')
+        return redirect(url_for('radionuclides.manage_radionuclides'))
+
+    if request.method == 'POST':
+        try:
+            entity['half_life'] = float(request.form.get('half_life'))
+        except (ValueError, TypeError):
+            flash('Half life must be a number.', 'error')
+            return redirect(url_for('radionuclides.edit_radionuclide', row_key=row_key))
+        table_mgr.upload_batch_to_table(RADIONUCLIDE_TABLE, [entity])
+        flash('Radionuclide updated.', 'success')
+        return redirect(url_for('radionuclides.manage_radionuclides'))
+
+    return render_template('edit_radionuclide.html', radionuclide=entity)
+
+
+@login_required
+@radionuclide_bp.route('/radionuclides/delete/<row_key>', methods=['POST'])
+def delete_radionuclide(row_key):
+    table_mgr = get_table_manager()
+    username = current_user.username
+    entity = table_mgr.get_entity(RADIONUCLIDE_TABLE, username, row_key)
+    if entity:
+        table_mgr.delete_entities(RADIONUCLIDE_TABLE, [entity])
+        flash('Radionuclide deleted.', 'success')
+    else:
+        flash('Radionuclide not found.', 'error')
+    return redirect(url_for('radionuclides.manage_radionuclides'))

--- a/app/radionuclide/templates/add_radionuclide.html
+++ b/app/radionuclide/templates/add_radionuclide.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block title %}Add Radionuclide{% endblock %}
+{% block content %}
+<h2>Add Radionuclide</h2>
+<form method="post" action="{{ url_for('radionuclides.add_radionuclide') }}">
+  <div>
+    <label for="name">Name:</label>
+    <input type="text" name="name" id="name" required>
+  </div>
+  <div>
+    <label for="half_life">Half life (min):</label>
+    <input type="number" step="any" name="half_life" id="half_life" required>
+  </div>
+  <button type="submit">Add</button>
+</form>
+{% endblock %}

--- a/app/radionuclide/templates/edit_radionuclide.html
+++ b/app/radionuclide/templates/edit_radionuclide.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Edit Radionuclide{% endblock %}
+{% block content %}
+<h2>Edit Radionuclide</h2>
+<form method="post" action="{{ url_for('radionuclides.edit_radionuclide', row_key=radionuclide.RowKey) }}">
+  <div>
+    <label>Name:</label> {{ radionuclide.RowKey }}
+  </div>
+  <div>
+    <label for="half_life">Half life (min):</label>
+    <input type="number" step="any" name="half_life" id="half_life" value="{{ radionuclide.half_life }}" required>
+  </div>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/radionuclide/templates/radionuclide.html
+++ b/app/radionuclide/templates/radionuclide.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Radionuclides{% endblock %}
+{% block content %}
+<h2>Manage Radionuclides</h2>
+<a href="{{ url_for('radionuclides.add_radionuclide') }}" class="btn btn-edit">Add New Radionuclide</a>
+<table border="1" cellpadding="5" cellspacing="0">
+  <thead>
+    <tr><th>Name</th><th>Half Life (min)</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    {% for rad in radionuclides %}
+    <tr>
+      <td>{{ rad.RowKey }}</td>
+      <td>{{ rad.half_life }}</td>
+      <td>
+        <a href="{{ url_for('radionuclides.edit_radionuclide', row_key=rad.RowKey) }}" class="btn btn-edit">Edit</a>
+        <form method="post" action="{{ url_for('radionuclides.delete_radionuclide', row_key=rad.RowKey) }}" style="display:inline;">
+          <button type="submit" class="btn btn-delete" onclick="return confirm('Delete this radionuclide?');">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/radiopharmaceutical/templates/add_radiopharm.html
+++ b/app/radiopharmaceutical/templates/add_radiopharm.html
@@ -7,10 +7,13 @@
     <label for="name">Pharmaceutical Name:</label>
     <input type="text" name="name" id="name" required>
   </div>
-  <!-- New Half life input inserted as second row -->
   <div>
-    <label for="half_life">Half life (mins):</label>
-    <input type="number" step="any" name="half_life" id="half_life" required>
+    <label for="radionuclide">Radionuclide:</label>
+    <select name="radionuclide" id="radionuclide" required>
+      {% for rad in radionuclides %}
+        <option value="{{ rad.RowKey }}">{{ rad.RowKey }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div>
     <label>Price per 1GBq:</label>

--- a/app/radiopharmaceutical/templates/edit_radiopharm.html
+++ b/app/radiopharmaceutical/templates/edit_radiopharm.html
@@ -7,10 +7,13 @@
     <label for="name">Pharmaceutical Name:</label>
     <input type="text" name="name" id="name" value="{{ record.type }}" required>
   </div>
-  <!-- New Half life input inserted as second row -->
   <div>
-    <label for="half_life">Half life (mins):</label>
-    <input type="number" step="any" name="half_life" id="half_life" value="{{ record.half_life }}" required>
+    <label for="radionuclide">Radionuclide:</label>
+    <select name="radionuclide" id="radionuclide" required>
+      {% for rad in radionuclides %}
+        <option value="{{ rad.RowKey }}" {% if record.radionuclide == rad.RowKey %}selected{% endif %}>{{ rad.RowKey }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div>
     <label>Price per 1GBq:</label>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,6 +17,7 @@
                 <li><a href="{{ url_for('user.manage_users') }}">Users</a></li>
             {% endif %}
           <li><a href="{{ url_for('radiopharm.manage') }}">Radiopharmaceuticals</a></li>
+          <li><a href="{{ url_for('radionuclides.manage_radionuclides') }}">Radionuclides</a></li>
           <li><a href="{{ url_for('dosing_schemes.list_dosing_schemes') }}">Dosing</a></li>
           <li><a href="{{ url_for('daysetup.plan_daysetup') }}">DaySetup</a></li>
           <li><a href="{{ url_for('patients.manage_patients') }}">Patients</a></li>


### PR DESCRIPTION
## Summary
- create a new `radionuclide` blueprint with CRUD operations and defaults
- register the new blueprint and table
- track radionuclide for each radiopharmaceutical
- update forms and templates to select radionuclide
- add navigation link to radionuclide management

## Testing
- `python -m py_compile app/radionuclide/radionuclide.py app/radiopharmaceutical/radiopharmaceutical.py`

------
https://chatgpt.com/codex/tasks/task_e_683edb0ac3b483279162413f7a3ed82c