### PR TITLE
Add admin time, note, immobility fields to patients

### DIFF
--- a/app/patients/templates/edit_patient.html
+++ b/app/patients/templates/edit_patient.html
@@ -44,6 +44,28 @@
                     {# Options will be populated via JavaScript #}
                 </select>
             </div>
+            <div>
+                <label for="admin_time">Adm. Time:</label>
+                <select name="admin_time" id="admin_time">
+                    {% for t in time_options %}
+                        <option value="{{ t }}" {% if patient.AdminTime==t %}selected{% endif %}>{{ t }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <div style="display: flex; gap: 20px; align-items: flex-start; margin-top: 10px;">
+            <div>
+                <label for="note">Note:</label>
+                <input type="text" name="note" id="note" value="{{ patient.Note }}">
+            </div>
+            <div>
+                <label for="immobility">Immobility:</label>
+                <select name="immobility" id="immobility">
+                    <option value="no" {% if not patient.Immobility %}selected{% endif %}>No</option>
+                    <option value="yes" {% if patient.Immobility %}selected{% endif %}>Yes</option>
+                </select>
+            </div>
         </div>
 
         <p>

--- a/app/patients/templates/patients.html
+++ b/app/patients/templates/patients.html
@@ -41,6 +41,28 @@
                     {# Options will be populated dynamically #}
                 </select>
             </div>
+            <div>
+                <label for="admin_time">Adm. Time:</label>
+                <select name="admin_time" id="admin_time">
+                    {% for t in time_options %}
+                        <option value="{{ t }}">{{ t }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+
+        <div style="display: flex; gap: 20px; align-items: flex-start; margin-top: 10px;">
+            <div>
+                <label for="note">Note:</label>
+                <input type="text" name="note" id="note">
+            </div>
+            <div>
+                <label for="immobility">Immobility:</label>
+                <select name="immobility" id="immobility">
+                    <option value="no">No</option>
+                    <option value="yes">Yes</option>
+                </select>
+            </div>
         </div>
 
         <p>
@@ -65,7 +87,7 @@
                     <th>Dose (MBq)</th>
                     <th>Adm. Time</th>
                     <th>Note</th>
-                    <th>Imobility</th>
+                    <th>Immobility</th>
                     <th>Actions</th>
                 </tr>
             </thead>
@@ -85,9 +107,9 @@
                         </td>
                         <td>{{ dosing_scheme_by_rowkey[patient.DosingSchemeID]['Name'] }}</td>
                         <td>{{ "{:.1f}".format(patient.AdministeredDose) }}</td>
-                        <td>not def</td>
-                        <td>some note</td>
-                        <td>yes/no</td>
+                        <td>{{ patient.AdminTime or '' }}</td>
+                        <td>{{ patient.Note or '' }}</td>
+                        <td>{{ 'Yes' if patient.Immobility else 'No' }}</td>
                         <td>
                             <div style="display: flex; gap: 5px; align-items: stretch;">
                                 <div style="flex: 1;">


### PR DESCRIPTION
## Summary
- extend Patients blueprint with admin time, note and immobility fields
- show new fields in patient table
- allow editing the new values

## Testing
- `pytest` *(no tests found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pip install pylint` *(fails: Could not find a version that satisfies the requirement pylint)*

------
https://chatgpt.com/codex/tasks/task_e_683ef599acc48327873ebb3604123107