### PR TITLE
Add 'N/A' option for admin time

### DIFF
--- a/app/patients/patients.py
+++ b/app/patients/patients.py
@@ -12,8 +12,9 @@ from app.table_manager import get_table_manager
 
 
 def _time_options():
-    """Return a list of time strings in 5 minute intervals."""
-    return [f"{h:02d}:{m:02d}" for h in range(7, 18) for m in range(0, 60, 5)]
+    """Return a list of time strings in 5 minute intervals plus an 'N/A' option."""
+    times = [f"{h:02d}:{m:02d}" for h in range(7, 18) for m in range(0, 60, 5)]
+    return ["N/A"] + times
 
 patients_bp = Blueprint('patients', __name__, template_folder='templates')
 fernet = get_fernet()

--- a/app/patients/templates/edit_patient.html
+++ b/app/patients/templates/edit_patient.html
@@ -48,7 +48,7 @@
                 <label for="admin_time">Adm. Time:</label>
                 <select name="admin_time" id="admin_time">
                     {% for t in time_options %}
-                        <option value="{{ t }}" {% if patient.AdminTime==t %}selected{% endif %}>{{ t }}</option>
+                        <option value="{{ t }}" {% if patient.AdminTime==t or (not patient.AdminTime and t=='N/A') %}selected{% endif %}>{{ t }}</option>
                     {% endfor %}
                 </select>
             </div>


### PR DESCRIPTION
## Summary
- allow patients to set 'N/A' as the administration time
- select N/A by default when editing a patient with no saved time

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4b66ee988327ab52c7a45d56e266